### PR TITLE
Optimize get_graph

### DIFF
--- a/skeletor/skeletonize/base.py
+++ b/skeletor/skeletonize/base.py
@@ -165,8 +165,7 @@ class Skeleton:
         dists = np.sqrt((dists ** 2).sum(axis=1))
 
         G = nx.DiGraph()
-        G.add_weighted_edges_from([(s, t, w) for s, t, w in zip(nodes.node_id.values,
-                                                                nodes.parent_id.values, dists)])
+        G.add_weighted_edges_from(zip(nodes.node_id.values, nodes.parent_id.values, dists))
 
         return G
 


### PR DESCRIPTION
You are just unpacking a generator of tuples and then repacking them into a tuple in a list comprehension. The better way to handle this would be just using `list(zip(a,b,c))`, however, glancing at the networkx source code, it seems it actually only need an iterable here, not a container. Therefore, the generator should be fine.